### PR TITLE
turned eslint linebreak-style rule off

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -8,6 +8,7 @@
       "jsx-a11y"
     ],
     "rules": {
-      "react/jsx-filename-extension": [1, { "extensions": [".js", ".jsx"] }]
+      "react/jsx-filename-extension": [1, { "extensions": [".js", ".jsx"] }],
+      "linebreak-style": "off"
     }
 }


### PR DESCRIPTION
Added a rule in the .eslintrc file that turns off the linebreak style rule. The air bnb style guide requires an end-of-line style of LF ( or /n), but git converts the files to CRLF (\r\n) when pushing to github. The linebreak-style rule is being turned off until a better solution is reached.