### PR TITLE
Bud 9 transaction dates incorrect in table

### DIFF
--- a/src/transactions/TransactionRow.js
+++ b/src/transactions/TransactionRow.js
@@ -31,7 +31,7 @@ function TransactionRow({ transaction }) {
   };
 
   // Format the date in this format: M-D-YYYY
-  const dateString = `${transaction.date.getUTCMonth()+1}-${transaction.date.getUTCDate()}-${transaction.date.getUTCFullYear()}`;
+  const dateString = `${transaction.date.getUTCMonth() + 1}-${transaction.date.getUTCDate()}-${transaction.date.getUTCFullYear()}`;
 
   // Format the amount in this format: -$MMM,MMM.MM
   const formattedAmount = Number(Math.abs(transaction.amount))


### PR DESCRIPTION
Added spaces before and after plus sign in Transaction Row to cater to ESLInt error.