### PR TITLE
Bud 2 test budget at a glance

### DIFF
--- a/src/home/BudgetAtAGlanceWidget.js
+++ b/src/home/BudgetAtAGlanceWidget.js
@@ -1,0 +1,7 @@
+import React from 'react';
+
+export default function BudgetAtAGlance() {
+  return (
+    <div />
+  );
+}

--- a/src/home/__test__/BudgetAtAGlanceWidget.test.js
+++ b/src/home/__test__/BudgetAtAGlanceWidget.test.js
@@ -4,7 +4,7 @@ import {
   render, screen, TestData,
 } from '../../test';
 
-describe('BudgetAtAGlanceWidget', () => {
+describe.skip('BudgetAtAGlanceWidget', () => {
   it('displays correctly with no transactions', () => {
     // Arrange with no transactions and one $500 category, at the end of the month
     const transactions = [];

--- a/src/home/__test__/BudgetAtAGlanceWidget.test.js
+++ b/src/home/__test__/BudgetAtAGlanceWidget.test.js
@@ -49,34 +49,33 @@ describe('BudgetAtAGlanceWidget', () => {
     const testState = TestData.getState(transactions);
     const testDate = new Date('6-1-22');
     render(<BudgetAtAGlanceWidget testDate={testDate} />, { preloadedState: testState });
-    // Assert spent message shows correct spending
-    screen.logTestingPlaygroundURL();
+
+    // Assert spent message shows $0 spent and an extra $1000 to spend
     screen.getByText(/\$0 spent out of \( \$2300\+ \$1000\)/i);
     // Assert on track message is displayed
     screen.getByText(/on track/i);
     // Assert progress bar is empty
     const progressBar = screen.getByRole('progressbar');
     expect(progressBar).toHaveAttribute('aria-valuenow', '0');
-    expect(progressBar).toHaveAttribute('aria-valuemax', '2300');
+    expect(progressBar).toHaveAttribute('aria-valuemax', '3300');
   });
 
   it('displays correctly with positive and negative transactions', () => {
-    // Arrange with 5 categories, at the end of the month
-    // and 5 transactions that should be ignored: 1 positive Income, 1 negative Income,
-    // 1 day before the month, 1 day after the month, 1 same month previous year
+    // Arrange with 2 transactions (1 positive, 1 negative that together add up to negative)
+    // 5 categories, 66% through the month
     const categoryIds = ['2457cec9-d841-49d7-9fba-8c6e852cbc22', '59726654-f530-4d5d-976c-006173cdd86a'];
     const transactions = TestData.getTransactions([-2000, 160], new Date('6-15-2022'), categoryIds);
     const testState = TestData.getState(transactions);
     const testDate = new Date('6-20-22');
     render(<BudgetAtAGlanceWidget testDate={testDate} />, { preloadedState: testState });
 
-    // Assert spent message shows correct spending
+    // Assert spent message shows $1840 spent
     screen.getByText(/\$1840 spent out of \$2300/i);
-    // Assert under budget message is displayed
+    // Assert over budget message is displayed
     screen.getByText(/over budget/i);
-    // Assert progress bar is empty
+    // Assert progress bar is 80% full
     const progressBar = screen.getByRole('progressbar');
-    expect(progressBar).toHaveAttribute('aria-valuenow', '0');
+    expect(progressBar).toHaveAttribute('aria-valuenow', '1840');
     expect(progressBar).toHaveAttribute('aria-valuemax', '2300');
   });
 
@@ -94,7 +93,7 @@ describe('BudgetAtAGlanceWidget', () => {
     const testDate = new Date('6-30-22');
     render(<BudgetAtAGlanceWidget testDate={testDate} />, { preloadedState: testState });
 
-    // Assert spent message shows correct spending
+    // Assert spent message shows no spending
     screen.getByText(/\$0 spent out of \$2300/i);
     // Assert under budget message is displayed
     screen.getByText(/under budget/i);

--- a/src/home/__test__/BudgetAtAGlanceWidget.test.js
+++ b/src/home/__test__/BudgetAtAGlanceWidget.test.js
@@ -1,0 +1,106 @@
+import React from 'react';
+import BudgetAtAGlanceWidget from '../BudgetAtAGlanceWidget';
+import {
+  render, screen, TestData,
+} from '../../test';
+
+describe('BudgetAtAGlanceWidget', () => {
+  it('displays correctly with no transactions', () => {
+    // Arrange with no transactions and one $500 category, at the end of the month
+    const transactions = [];
+    const categories = [TestData.getCategory(500)];
+    const testState = TestData.getState(transactions, categories);
+    const testDate = new Date('6-30-22');
+    render(<BudgetAtAGlanceWidget testDate={testDate} />, { preloadedState: testState });
+
+    // Assert spent message shows no spending
+    screen.getByText(/\$0 spent out of \$2300/i);
+    // Assert under budget message is displayed
+    screen.getByText(/under budget/i);
+    // Assert progress bar is empty
+    const progressBar = screen.getByRole('progressbar');
+    expect(progressBar).toHaveAttribute('aria-valuenow', '0');
+    expect(progressBar).toHaveAttribute('aria-valuemax', '2300');
+  });
+
+  it('displays correctly with only negative transactions', () => {
+    // Arrange with 3 negative transactions, 5 categories, at the beginning of the month
+    const categoryIds = ['2457cec9-d841-49d7-9fba-8c6e852cbc22',
+      '59726654-f530-4d5d-976c-006173cdd86a', '59726654-f530-4d5d-976c-006173cdd86a'];
+    const transactions = TestData.getTransactions([-1005, -68, -77], new Date('6-5-22'), categoryIds);
+    const testState = TestData.getState(transactions);
+    const testDate = new Date('6-1-22');
+    render(<BudgetAtAGlanceWidget testDate={testDate} />, { preloadedState: testState });
+
+    // Assert spent message shows $1150 spending
+    screen.getByText(/\$1150 spent out of \$2300/i);
+    // Assert over budget message is displayed
+    screen.getByText(/over budget/i);
+    // Assert progress bar is halfway
+    const progressBar = screen.getByRole('progressbar');
+    expect(progressBar).toHaveAttribute('aria-valuenow', '1150');
+    expect(progressBar).toHaveAttribute('aria-valuemax', '2300');
+  });
+
+  it('displays correctly with only positive transactions', () => {
+    // Arrange with 2 positive transactions, 5 categories, at the beginning of the month
+    const categoryIds = ['2457cec9-d841-49d7-9fba-8c6e852cbc22', '59726654-f530-4d5d-976c-006173cdd86a'];
+    const transactions = TestData.getTransactions([500, 500], new Date('6-5-22'), categoryIds);
+    const testState = TestData.getState(transactions);
+    const testDate = new Date('6-1-22');
+    render(<BudgetAtAGlanceWidget testDate={testDate} />, { preloadedState: testState });
+    // Assert spent message shows correct spending
+    screen.logTestingPlaygroundURL();
+    screen.getByText(/\$0 spent out of \( \$2300\+ \$1000\)/i);
+    // Assert on track message is displayed
+    screen.getByText(/on track/i);
+    // Assert progress bar is empty
+    const progressBar = screen.getByRole('progressbar');
+    expect(progressBar).toHaveAttribute('aria-valuenow', '0');
+    expect(progressBar).toHaveAttribute('aria-valuemax', '2300');
+  });
+
+  it('displays correctly with positive and negative transactions', () => {
+    // Arrange with 5 categories, at the end of the month
+    // and 5 transactions that should be ignored: 1 positive Income, 1 negative Income,
+    // 1 day before the month, 1 day after the month, 1 same month previous year
+    const categoryIds = ['2457cec9-d841-49d7-9fba-8c6e852cbc22', '59726654-f530-4d5d-976c-006173cdd86a'];
+    const transactions = TestData.getTransactions([-2000, 160], new Date('6-15-2022'), categoryIds);
+    const testState = TestData.getState(transactions);
+    const testDate = new Date('6-20-22');
+    render(<BudgetAtAGlanceWidget testDate={testDate} />, { preloadedState: testState });
+
+    // Assert spent message shows correct spending
+    screen.getByText(/\$1840 spent out of \$2300/i);
+    // Assert under budget message is displayed
+    screen.getByText(/over budget/i);
+    // Assert progress bar is empty
+    const progressBar = screen.getByRole('progressbar');
+    expect(progressBar).toHaveAttribute('aria-valuenow', '0');
+    expect(progressBar).toHaveAttribute('aria-valuemax', '2300');
+  });
+
+  it('doesn\'t count Income transactions or transactions outside the month', () => {
+    // Arrange with 5 categories, at the end of the month
+    // and 5 transactions that should be ignored: 1 positive Income, 1 negative Income,
+    // 1 day before the month, 1 day after the month, 1 same month previous year
+    const transactions = TestData.getTransactions(
+      [-100, 200, -300, -400, -500],
+      [new Date('6-15-2022'), new Date('6-15-2022'), new Date('5-31-2022'), new Date('7-1-2022'), new Date('6-15-2021')],
+      ['6321da2a-98ef-457d-8357-797a9041fe10', '6321da2a-98ef-457d-8357-797a9041fe10',
+        '2457cec9-d841-49d7-9fba-8c6e852cbc22', '59726654-f530-4d5d-976c-006173cdd86a'],
+    );
+    const testState = TestData.getState(transactions);
+    const testDate = new Date('6-30-22');
+    render(<BudgetAtAGlanceWidget testDate={testDate} />, { preloadedState: testState });
+
+    // Assert spent message shows correct spending
+    screen.getByText(/\$0 spent out of \$2300/i);
+    // Assert under budget message is displayed
+    screen.getByText(/under budget/i);
+    // Assert progress bar is empty
+    const progressBar = screen.getByRole('progressbar');
+    expect(progressBar).toHaveAttribute('aria-valuenow', '0');
+    expect(progressBar).toHaveAttribute('aria-valuemax', '2300');
+  });
+});

--- a/src/test/TestData.js
+++ b/src/test/TestData.js
@@ -1,78 +1,125 @@
+import { v4 as uuid } from 'uuid';
+
 /**
- * Gets five test transactions
+ * Creates a new transaction object with the specified data
+ *
+ * @param {number} amount - the amount of the transaction (can be null or not provided)
+ * @param {Object} date - the date of the transaction (can be null or not provided)
+ * @param {string} categoryId - the categoryId of the transaction (can be null or not provided)
+ * @returns a new transaction object
+ */
+export const getTransaction = (amount, date, categoryId) => ({
+  id: uuid(),
+  date: date || new Date(),
+  payee: 'Ullrich Group',
+  categoryId: categoryId || 1,
+  notes: '',
+  amount: amount || 0,
+});
+
+/**
+ * Gets an array of transactions for testing
+ * If no parameters are given, then it returns 5 test transactions
  * All have either categoryId 0 or categoryId 4
  *
- * @returns - 5 test transactions
+ * @param {number[]} amounts - an array of the amounts to use
+ * @param {Object[]} dates - an array of dates or one date (optional)
+ * @param {string[]} categoryIds - an array of category ids or one category id (optional)
+ * @returns an array of test transactions
  */
-export const getTransactions = () => [
-  {
-    id: '3b2e29b6-d911-4c8b-8e4e-5808f7559418',
-    date: new Date('2021-03-24'),
-    payee: 'Tromp, Howell and Grant',
-    categoryId: 4,
-    notes: 'nulla neque libero convallis',
-    amount: -297.8,
-  },
-  {
-    id: 'abf3abac-3d22-488d-b208-dc9b1e44008e',
-    date: new Date('2022-02-27'),
-    payee: 'Ullrich Group',
-    categoryId: 0,
-    notes: 'nullam varius nulla facilisi',
-    amount: 240.2,
-  }, {
-    id: '7e66e23e-d99e-48ba-8cff-195911f6c06e',
-    date: new Date('2022-01-01'),
-    payee: 'Tromp, Howell and Grant',
-    categoryId: 0,
-    notes: '',
-    amount: 46.5,
-  }, {
-    id: '0249ab94-b9b2-4890-9fff-09408a9a18d8',
-    date: new Date('2021-12-31'),
-    payee: 'Macejkovic, Sipes and Swift',
-    categoryId: 4,
-    notes: 'quam sollicitudin vitae consectetuer eget',
-    amount: -147.97,
-  }, {
-    id: '5ab89d1b-6199-4e3a-bc40-047788dad4cb',
-    date: new Date('2021-05-13'),
-    payee: 'Bergnaum-Pouros',
-    categoryId: 4,
-    notes: '',
-    amount: -295.46,
-  },
-];
+export const getTransactions = (amounts, dates, categories) => {
+  // Return a custom list of transactions
+  if (Array.isArray(amounts)) {
+    return amounts.map((amount, index) => {
+      const date = (Array.isArray(dates)) ? dates[index] : dates;
+      const category = (Array.isArray(categories)) ? categories[index] : categories;
+      return getTransaction(amount, date, category);
+    });
+  }
+  // Or return a default list of 5 transactions
+  return [
+    {
+      id: '3b2e29b6-d911-4c8b-8e4e-5808f7559418',
+      date: new Date('2021-03-24'),
+      payee: 'Tromp, Howell and Grant',
+      categoryId: '91c33650-6df8-4845-b3e3-2450bed8541c',
+      notes: 'nulla neque libero convallis',
+      amount: -297.8,
+    },
+    {
+      id: 'abf3abac-3d22-488d-b208-dc9b1e44008e',
+      date: new Date('2022-02-27'),
+      payee: 'Ullrich Group',
+      categoryId: '6321da2a-98ef-457d-8357-797a9041fe10',
+      notes: 'nullam varius nulla facilisi',
+      amount: 240.2,
+    }, {
+      id: '7e66e23e-d99e-48ba-8cff-195911f6c06e',
+      date: new Date('2022-01-01'),
+      payee: 'Tromp, Howell and Grant',
+      categoryId: '6321da2a-98ef-457d-8357-797a9041fe10',
+      notes: '',
+      amount: 46.5,
+    }, {
+      id: '0249ab94-b9b2-4890-9fff-09408a9a18d8',
+      date: new Date('2021-12-31'),
+      payee: 'Macejkovic, Sipes and Swift',
+      categoryId: '91c33650-6df8-4845-b3e3-2450bed8541c',
+      notes: 'quam sollicitudin vitae consectetuer eget',
+      amount: -147.97,
+    }, {
+      id: '5ab89d1b-6199-4e3a-bc40-047788dad4cb',
+      date: new Date('2021-05-13'),
+      payee: 'Bergnaum-Pouros',
+      categoryId: '91c33650-6df8-4845-b3e3-2450bed8541c',
+      notes: '',
+      amount: -295.46,
+    },
+  ];
+};
+
+/**
+ * Creates a new category with the specified target
+ * Default target is 0
+ *
+ * @param {number} target - the target of the category (can be null or not provided)
+ * @returns a new category object
+ */
+export const getCategory = (target) => ({
+  id: uuid(),
+  name: 'Groceries',
+  target: target || 0,
+});
 
 /**
  * Gets five test categories
  * Income has an index of 0
  *
- * @returns - 5 test categories
+ * @returns 5 test categories
  */
 export const getCategories = () => [
   {
-    id: 0,
+    id: '6321da2a-98ef-457d-8357-797a9041fe10',
     name: 'Income',
     target: 3000,
   },
   {
-    id: 1,
+    id: '2457cec9-d841-49d7-9fba-8c6e852cbc22',
     name: 'Rent',
     target: 1500,
   },
   {
-    id: 2,
+    id: '59726654-f530-4d5d-976c-006173cdd86a',
     name: 'Groceries',
     target: 400,
   },
   {
-    id: 3,
+    id: '85bc38b9-4ebe-4639-b82a-789b4918f9e6',
     name: 'Gas',
     target: 150,
   },
   {
-    id: 4,
+    id: '91c33650-6df8-4845-b3e3-2450bed8541c',
     name: 'Shopping',
     target: 250,
   },
@@ -84,8 +131,8 @@ export const getCategories = () => [
  * If no categories are provided (null or no argument), defaults to 5 test categories
  *
  * @param {*} transactions - the transactions to use (can be null or not provided)
- * @param {*} categoires - the categories to use (can be null or not provided)
- * @returns - a new state object for preloading in a test Redux store
+ * @param {*} categories - the categories to use (can be null or not provided)
+ * @returns a new state object for preloading in a test Redux store
  */
 export const getState = (
   transactions = getTransactions(),

--- a/src/test/TestData.js
+++ b/src/test/TestData.js
@@ -3,36 +3,37 @@ import { v4 as uuid } from 'uuid';
 /**
  * Creates a new transaction object with the specified data
  *
- * @param {number} amount - the amount of the transaction (can be null or not provided)
- * @param {Object} date - the date of the transaction (can be null or not provided)
- * @param {string} categoryId - the categoryId of the transaction (can be null or not provided)
+ * @param {?number} amount - the amount of the transaction (can be null or not provided)
+ * @param {?Object} date - the date of the transaction (can be null or not provided)
+ * @param {?string} categoryId - the categoryId of the transaction (can be null or not provided)
  * @returns a new transaction object
  */
 export const getTransaction = (amount, date, categoryId) => ({
   id: uuid(),
   date: date || new Date(),
   payee: 'Ullrich Group',
-  categoryId: categoryId || 1,
+  categoryId: categoryId || '2457cec9-d841-49d7-9fba-8c6e852cbc22',
   notes: '',
   amount: amount || 0,
 });
 
 /**
  * Gets an array of transactions for testing
- * If no parameters are given, then it returns 5 test transactions
- * All have either categoryId 0 or categoryId 4
+ * Can specify amounts, dates and categories for the generated transactions
+ * If no parameters are given, then it returns 5 default transactions
+ * All default transactions have a category of Income or Shopping
  *
  * @param {number[]} amounts - an array of the amounts to use
- * @param {Object[]} dates - an array of dates or one date (optional)
- * @param {string[]} categoryIds - an array of category ids or one category id (optional)
+ * @param {?Object[] | Object} dates - an array of dates or one date (optional)
+ * @param {?string[] | string} categoryIds - an array of category ids or one category id (optional)
  * @returns an array of test transactions
  */
-export const getTransactions = (amounts, dates, categories) => {
+export const getTransactions = (amounts, dates, categoryIds) => {
   // Return a custom list of transactions
   if (Array.isArray(amounts)) {
     return amounts.map((amount, index) => {
       const date = (Array.isArray(dates)) ? dates[index] : dates;
-      const category = (Array.isArray(categories)) ? categories[index] : categories;
+      const category = (Array.isArray(categoryIds)) ? categoryIds[index] : categoryIds;
       return getTransaction(amount, date, category);
     });
   }
@@ -82,7 +83,7 @@ export const getTransactions = (amounts, dates, categories) => {
  * Creates a new category with the specified target
  * Default target is 0
  *
- * @param {number} target - the target of the category (can be null or not provided)
+ * @param {?number} target - the target of the category (can be null or not provided)
  * @returns a new category object
  */
 export const getCategory = (target) => ({
@@ -93,7 +94,7 @@ export const getCategory = (target) => ({
 
 /**
  * Gets five test categories
- * Income has an index of 0
+ * Income has an index of '6321da2a-98ef-457d-8357-797a9041fe10'
  *
  * @returns 5 test categories
  */
@@ -130,8 +131,8 @@ export const getCategories = () => [
  * If no transactions are provided (null or no argument), defaults to 5 test transactions
  * If no categories are provided (null or no argument), defaults to 5 test categories
  *
- * @param {*} transactions - the transactions to use (can be null or not provided)
- * @param {*} categories - the categories to use (can be null or not provided)
+ * @param {?Object[]} transactions - the transactions to use (can be null or not provided)
+ * @param {?Object[]} categories - the categories to use (can be null or not provided)
  * @returns a new state object for preloading in a test Redux store
  */
 export const getState = (

--- a/src/transactions/__test__/TransactionTable.test.js
+++ b/src/transactions/__test__/TransactionTable.test.js
@@ -8,7 +8,7 @@ const testTransaction = {
   id: '3b2e29b6-d911-4c8b-8e4e-5808f7559418',
   date: new Date('2021-03-24'),
   payee: 'Tromp, Howell and Grant',
-  categoryId: 4,
+  categoryId: '91c33650-6df8-4845-b3e3-2450bed8541c',
   notes: 'nulla neque libero convallis',
   amount: -297.8,
 };


### PR DESCRIPTION
Wrote basic tests for the Budget At a Glance widget that's in development.

The tests covered these scenarios:
- no transactions
- only negative transactions
- only positive transactions
- negative and positive transactions that add up to negative
- only transactions that should not be counted (income & outside the month boundary)

They were tested against dates that put the spending under budget, on track, and over budget.

Also made updates to the test data generator code to allow for more complex transaction data generation and to update the ids of generated categories to be UUIDs. This required a few small updates to the TransactionTable tests.

The tests are currently set to be skipped until the component is completed.